### PR TITLE
Update dependencies and compatible Ruby runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: Tests
+on: [pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        ruby: ["2.7", "3.0", "3.1", "3.2"]
+    name: Ruby ${{ matrix.ruby }} tests
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: |
+          bundle install
+          bundle exec rspec spec
+      - uses: joshmfrankel/simplecov-check-action@main
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: ruby
-rvm:
-  - "2.1.0"
-  - "2.0.0"
-  - "1.9.3"
-script: bundle exec rspec spec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,50 +1,65 @@
 PATH
   remote: .
   specs:
-    utterson (0.2.2)
-      nokogiri (~> 1.6.0)
-      ruby-progressbar (~> 1.4.0)
-      trollop (~> 2.0)
+    utterson (0.3.2)
+      nokogiri (~> 1.14.0)
+      optimist (~> 3.0)
+      ruby-progressbar (~> 1.13.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.3.5)
-    crack (0.4.2)
-      safe_yaml (~> 1.0.0)
-    diff-lcs (1.2.5)
-    docile (1.1.2)
-    mini_portile (0.5.2)
-    multi_json (1.8.4)
-    nokogiri (1.6.1)
-      mini_portile (~> 0.5.0)
-    rake (10.1.1)
-    rspec (2.14.1)
-      rspec-core (~> 2.14.0)
-      rspec-expectations (~> 2.14.0)
-      rspec-mocks (~> 2.14.0)
-    rspec-core (2.14.7)
-    rspec-expectations (2.14.5)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.14.5)
-    ruby-progressbar (1.4.1)
-    safe_yaml (1.0.1)
-    simplecov (0.8.2)
-      docile (~> 1.1.0)
-      multi_json
-      simplecov-html (~> 0.8.0)
-    simplecov-html (0.8.0)
-    trollop (2.0)
-    webmock (1.17.2)
-      addressable (>= 2.2.7)
+    addressable (2.8.2)
+      public_suffix (>= 2.0.2, < 6.0)
+    crack (0.4.5)
+      rexml
+    diff-lcs (1.5.0)
+    docile (1.4.0)
+    hashdiff (1.0.1)
+    mini_portile2 (2.8.1)
+    nokogiri (1.14.2)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
+    optimist (3.0.1)
+    public_suffix (5.0.1)
+    racc (1.6.2)
+    rake (13.0.6)
+    rexml (3.2.5)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.1)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.0)
+    ruby-progressbar (1.13.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
+    webmock (3.18.1)
+      addressable (>= 2.8.0)
       crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  bundler (>= 1.12)
   rake
   rspec
   simplecov
   utterson!
-  webmock (~> 1.17.0)
+  webmock (~> 3.18.0)
+
+BUNDLED WITH
+   2.1.4

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 Simple utility to traverse directory of html files and check links in them.
 
 [![Gem Version](https://badge.fury.io/rb/utterson.png)](http://badge.fury.io/rb/utterson)
-[![Build Status](https://travis-ci.org/iiska/utterson.png)](https://travis-ci.org/iiska/utterson) [![Dependency Status](https://gemnasium.com/iiska/utterson.png)](https://gemnasium.com/iiska/utterson)
+[![Tests](https://github.com/iiska/utterson/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/iiska/utterson/actions/workflows/ci.yml)
+
 
 ## Getting started
 

--- a/bin/utterson
+++ b/bin/utterson
@@ -2,10 +2,10 @@
 
 $:.unshift File.join(File.dirname(__FILE__), *%w{ .. lib })
 
-require 'trollop'
+require 'optimist'
 require 'utterson'
 
-opts = Trollop::options do
+opts = Optimist::options do
   opt :root, "Root directory for the site if it differs from target dir", type: :string
 end
 

--- a/lib/utterson/html_check.rb
+++ b/lib/utterson/html_check.rb
@@ -84,7 +84,7 @@ module Utterson
       else
         path = File.expand_path(url, File.dirname(file))
       end
-      add_error(file, url, "File not found") unless File.exists? path
+      add_error(file, url, "File not found") unless File.exist? path
     end
 
     def add_error(file, url, response)

--- a/lib/utterson/version.rb
+++ b/lib/utterson/version.rb
@@ -1,3 +1,3 @@
 module Utterson
-  VERSION = '0.2.2'
+  VERSION = '0.3.2'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@
 require 'webmock/rspec'
 
 require 'simplecov'
+SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
 SimpleCov.start
 
 require 'utterson'

--- a/spec/utterson/base_spec.rb
+++ b/spec/utterson/base_spec.rb
@@ -11,7 +11,7 @@ module Utterson
        "spec/fixtures/dir-structure/2.html",
        "spec/fixtures/dir-structure/a/3.htm",
        "spec/fixtures/dir-structure/a/b/4.html"].each do |file|
-        HtmlCheck.should_receive(:new).with(file: file, root: dir)
+        expect(HtmlCheck).to receive(:new).with(file: file, root: dir)
       end
 
       u.check
@@ -23,7 +23,7 @@ module Utterson
         output = capture_stdout do
           u.check
         end
-        output.should match(/4 files with 0 urls checked/)
+        expect(output).to match(/4 files with 0 urls checked/)
       end
 
       it "should output error information" do
@@ -34,12 +34,12 @@ module Utterson
         output = capture_stdout do
           u.check
         end
-        output.should match("spec/fixtures/sample.html\n\tstyle.css\n"+
+        expect(output).to match("spec/fixtures/sample.html\n\tstyle.css\n"+
                             "\t\tFile not found")
-        output.should match("script.js\n\t\tFile not found")
-        output.should match("image.jpg\n\t\tFile not found")
-        output.should match("http://example.com\n\t\tHTTP 404")
-        output.should match("5 files with 4 urls checked and 4 errors found")
+        expect(output).to match("script.js\n\t\tFile not found")
+        expect(output).to match("image.jpg\n\t\tFile not found")
+        expect(output).to match("http://example.com\n\t\tHTTP 404")
+        expect(output).to match("5 files with 4 urls checked and 4 errors found")
       end
     end
   end

--- a/utterson.gemspec
+++ b/utterson.gemspec
@@ -16,13 +16,14 @@ Gem::Specification.new 'utterson', Utterson::VERSION do |s|
 
   s.test_files = Dir['spec/**/*']
 
-  s.required_ruby_version = ">= 1.9.3"
-  s.add_runtime_dependency 'trollop', '~> 2.0'
-  s.add_runtime_dependency 'nokogiri', '~> 1.6.0'
-  s.add_runtime_dependency 'ruby-progressbar', '~> 1.4.0'
+  s.required_ruby_version = '>= 2.7.0'
+  s.add_runtime_dependency 'optimist', '~> 3.0'
+  s.add_runtime_dependency 'nokogiri', '~> 1.14.0'
+  s.add_runtime_dependency 'ruby-progressbar', '~> 1.13.0'
 
+  s.add_development_dependency 'bundler', '>= 1.12'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'simplecov'
-  s.add_development_dependency 'webmock', '~> 1.17.0'
+  s.add_development_dependency 'webmock', '~> 3.18.0'
 end


### PR DESCRIPTION
- Replaces Travis CI with Github Actions
- Upgrade `nokogiri` to latest version, raising minimum required Ruby
  version to 2.7.0
- Upgrade `webmock` to latest
- Upgrade `ruby-progressbar` to latest
- Replace deprecated `trollop` with `optimist`
- Upgrade rest non-pinned gems with `bundle update`
- Fix specs related to `URI:InvalidURIError`
- Configure `simplecov` to use `HTMLFormatter`
- Fix RSpec deprecation warnings
- Fix support for Ruby 3.2.2